### PR TITLE
Close streams when they are from files

### DIFF
--- a/sparkcc.py
+++ b/sparkcc.py
@@ -200,6 +200,8 @@ class CCSparkJob:
                     for res in self.process_record(record):
                         yield res
                     self.records_processed.add(1)
+                if uri.startswith('file:'):
+                    stream.close()
             except ArchiveLoadFailed as exception:
                 self.warc_input_failed.add(1)
                 self.get_logger().error(

--- a/sparkcc.py
+++ b/sparkcc.py
@@ -200,12 +200,13 @@ class CCSparkJob:
                     for res in self.process_record(record):
                         yield res
                     self.records_processed.add(1)
-                if uri.startswith('file:'):
-                    stream.close()
             except ArchiveLoadFailed as exception:
                 self.warc_input_failed.add(1)
                 self.get_logger().error(
                     'Invalid WARC: {} - {}'.format(uri, exception))
+            finally:
+                if uri.startswith('file:'):
+                    stream.close()
 
     def process_record(self, record):
         raise NotImplementedError('Processing record needs to be customized')


### PR DESCRIPTION
My circumstances dictated that I had to download CC files from AWS and then parse then on my local cluster. When I did this I noticed that file handles weren't being closed, which quickly eats through available memory. Simple fix, though!