### PR TITLE
Add options to control spark resource allocation.

### DIFF
--- a/sparkcc.py
+++ b/sparkcc.py
@@ -81,6 +81,14 @@ class CCSparkJob(object):
                                 help="Logging level")
         arg_parser.add_argument("--spark-profiler", action='store_true',
                                 help="Enable PySpark profiler")
+        arg_parser.add_argument("--minimum_executors", type=int,
+                                default=0,
+                                help="sets spark.dynamicAllocation.minExecutors")
+        arg_parser.add_argument("--maximum_executors", type=int,
+                                default=0,
+                                help="sets spark.dynamicAllocation.maxExecutors")
+        arg_parser.add_argument("--maximize_resource_allocation", action='store_true',
+                                help="sets maximizeResourceAllocation (EMR-specific option)")
 
         self.add_arguments(arg_parser)
         args = arg_parser.parse_args()
@@ -129,6 +137,14 @@ class CCSparkJob(object):
 
         if self.args.spark_profiler:
             conf = conf.set("spark.python.profile", "true")
+        if self.args.minimum_executors > 0:
+            conf = conf.set("spark.dynamicAllocation.enabled", "true")
+            conf = conf.set("spark.dynamicAllocation.minExecutors", self.args.minimum_executors)
+        if self.args.maximum_executors > 0:
+            conf = conf.set("spark.dynamicAllocation.enabled", "true")
+            conf = conf.set("spark.dynamicAllocation.maxExecutors", self.args.maximum_executors)
+        if self.args.maximize_resource_allocation:
+            conf = conf.set("maximizeResourceAllocation", "true")
 
         sc = SparkContext(
             appName=self.name,


### PR DESCRIPTION
This PR adds a few more options to control resource allocation for cc-pyspark jobs.

```
--minimum_executors sets spark.dynamicAllocation.minExecutors
--maximum_executors sets spark.dynamicAllocation.maxExecutors
--maximize_resource_allocation sets maximizeResourceAllocation
```

I've read a few article on optimizing long-running Spark jobs and these options are frequently mentioned as things one should try. Using them has helped increase my cluster utilization.