### PR TITLE
Use index field "content_charset" to speed up HTML parsing of WARC payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ $SPARK_HOME/bin/spark-submit \
     --packages org.apache.hadoop:hadoop-aws:3.2.0 \
     --conf spark.hadoop.fs.s3a.aws.credentials.provider=org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider \
     ./cc_index_word_count.py \
-    --query "SELECT url, warc_filename, warc_record_offset, warc_record_length FROM ccindex WHERE crawl = 'CC-MAIN-2020-24' AND subset = 'warc' AND url_host_tld = 'is' LIMIT 10" \
+    --query "SELECT url, warc_filename, warc_record_offset, warc_record_length, content_charset FROM ccindex WHERE crawl = 'CC-MAIN-2020-24' AND subset = 'warc' AND url_host_tld = 'is' LIMIT 10" \
     s3a://commoncrawl/cc-index/table/cc-main/warc/ \
     myccindexwordcountoutput \
     --num_output_partitions 1 \

--- a/cc_index_word_count.py
+++ b/cc_index_word_count.py
@@ -38,22 +38,28 @@ class CCIndexWordCountJob(CCIndexWarcSparkJob, WordCountJob):
     def html_to_text(self, page, record):
         try:
             encoding = record.rec_headers['WARC-Identified-Content-Charset']
-            if encoding is None:
-                encoding = EncodingDetector.find_declared_encoding(page,
-                                                                   is_html=True)
-            soup = BeautifulSoup(page, "lxml", from_encoding=encoding)
-            for script in soup(["script", "style"]):
+            if not encoding:
+                for encoding in EncodingDetector(page, is_html=True).encodings:
+                    # take the first detected encoding
+                    break
+            soup = BeautifulSoup(page, 'lxml', from_encoding=encoding)
+            for script in soup(['script', 'style']):
                 script.extract()
-            return soup.get_text(" ", strip=True)
-        except:
+            return soup.get_text(' ', strip=True)
+        except Exception as e:
+            self.get_logger().error("Error converting HTML to text for {}: {}",
+                                    record.rec_headers['WARC-Target-URI'], e)
             self.records_parsing_failed.add(1)
-            return ""
+            return ''
 
     def process_record(self, record):
-        page = record.content_stream().read()
+        if record.rec_type != 'response':
+            # skip over WARC request or metadata records
+            return
         if not self.is_html(record):
             self.records_non_html.add(1)
             return
+        page = record.content_stream().read()
         text = self.html_to_text(page, record)
         words = map(lambda w: w.lower(),
                     WordCountJob.word_pattern.findall(text))

--- a/cc_index_word_count.py
+++ b/cc_index_word_count.py
@@ -37,8 +37,10 @@ class CCIndexWordCountJob(CCIndexWarcSparkJob, WordCountJob):
 
     def html_to_text(self, page, record):
         try:
-            encoding = EncodingDetector.find_declared_encoding(page,
-                                                               is_html=True)
+            encoding = record.rec_headers['WARC-Identified-Content-Charset']
+            if encoding is None:
+                encoding = EncodingDetector.find_declared_encoding(page,
+                                                                   is_html=True)
             soup = BeautifulSoup(page, "lxml", from_encoding=encoding)
             for script in soup(["script", "style"]):
                 script.extract()

--- a/html_tag_count.py
+++ b/html_tag_count.py
@@ -15,10 +15,9 @@ class TagCountJob(CCSparkJob):
 
     def process_record(self, record):
         if record.rec_type != 'response':
-            # WARC request or metadata records
+            # skip over WARC request or metadata records
             return
-        content_type = record.http_headers.get_header('content-type', None)
-        if content_type is None or 'html' not in content_type:
+        if not self.is_html(record):
             # skip non-HTML or unknown content types
             return
         data = record.content_stream().read()

--- a/sparkcc.py
+++ b/sparkcc.py
@@ -64,7 +64,9 @@ class CCSparkJob(object):
 
         arg_parser.add_argument("--num_input_partitions", type=int,
                                 default=self.num_input_partitions,
-                                help="Number of input splits/partitions")
+                                help="Number of input splits/partitions, "
+                                "number of parallel tasks to process WARC "
+                                "files/records")
         arg_parser.add_argument("--num_output_partitions", type=int,
                                 default=self.num_output_partitions,
                                 help="Number of output partitions")
@@ -376,7 +378,9 @@ class CCIndexWarcSparkJob(CCIndexSparkJob):
                             help="SQL query to select rows. Note: the result "
                             "is required to contain the columns `url', `warc"
                             "_filename', `warc_record_offset' and `warc_record"
-                            "_length', make sure they're SELECTed.")
+                            "_length', make sure they're SELECTed. The column"
+                            "`content_charset' is optional and is utilized to"
+                            "read WARC record payloads with the right encoding.")
         agroup.add_argument("--csv", default=None,
                             help="CSV file to load WARC records by filename, "
                             "offset and length. The CSV file must have column "
@@ -392,10 +396,13 @@ class CCIndexWarcSparkJob(CCIndexSparkJob):
         no_parse = (not self.warc_parse_http_header)
 
         for row in rows:
-            url = row[0]
-            warc_path = row[1]
-            offset = int(row[2])
-            length = int(row[3])
+            url = row['url']
+            warc_path = row['warc_filename']
+            offset = int(row['warc_record_offset'])
+            length = int(row['warc_record_length'])
+            content_charset = None
+            if 'content_charset' in row:
+                content_charset = row['content_charset']
             self.get_logger().debug("Fetching WARC record for {}".format(url))
             rangereq = 'bytes={}-{}'.format(offset, (offset+length-1))
             try:
@@ -412,6 +419,8 @@ class CCIndexWarcSparkJob(CCIndexSparkJob):
             try:
                 for record in ArchiveIterator(record_stream,
                                               no_record_parse=no_parse):
+                    # pass `content_charset` forward to subclass processing WARC records
+                    record.rec_headers['WARC-Identified-Content-Charset'] = content_charset
                     for res in self.process_record(record):
                         yield res
                     self.records_processed.add(1)
@@ -424,8 +433,10 @@ class CCIndexWarcSparkJob(CCIndexSparkJob):
     def run_job(self, sc, sqlc):
         sqldf = self.load_dataframe(sc, self.args.num_input_partitions)
 
-        warc_recs = sqldf.select("url", "warc_filename", "warc_record_offset",
-                                 "warc_record_length").rdd
+        columns = ['url', 'warc_filename', 'warc_record_offset', 'warc_record_length']
+        if 'content_charset' in sqldf.columns:
+            columns.append('content_charset')
+        warc_recs = sqldf.select(*columns).rdd
 
         output = warc_recs.mapPartitions(self.fetch_process_warc_records) \
             .reduceByKey(self.reduce_by_key_func)

--- a/sparkcc.py
+++ b/sparkcc.py
@@ -286,9 +286,11 @@ class CCSparkJob(object):
             (record.rec_headers['WARC-Identified-Payload-Type'] in
              html_types)):
             return True
-        for html_type in html_types:
-            if html_type in record.content_type:
-                return True
+        content_type = record.http_headers.get_header('content-type', None)
+        if content_type:
+            for html_type in html_types:
+                if html_type in content_type:
+                    return True
         return False
 
 


### PR DESCRIPTION
Since summer 2018 the Common Crawl URL indexes include the field/column `content_charset` which holds the character set identified by [Apache Tika](https://tika.apache.org/). In order to speed up the HTML parsing of the WARC payloads resp. the extraction of plain text from the HTML (which requires that the character encoding is known):
- pass the identified character set forward to the method performing the HTML parsing:
  - add to WARC record header as additional field `WARC-Identified-Content-Charset`
- use the field in cc_index_word_count.py and make the character set detection by Beutifulsoup obsolete