### PR TITLE
Use SparkSession instead of SQLContext, implements #24

### DIFF
--- a/linkmap2parquet.py
+++ b/linkmap2parquet.py
@@ -15,15 +15,15 @@ class LinkMapImportJob(CCSparkJob):
     def map_line(self, line):
         return line.split('\t')
 
-    def run_job(self, sc, sqlc):
+    def run_job(self, session):
         output = None
         if self.args.input != '':
-            input_data = sc.textFile(
+            input_data = session.sparkContext.textFile(
                 self.args.input,
                 minPartitions=self.args.num_input_partitions)
             output = input_data.map(self.map_line)
 
-        df = sqlc.createDataFrame(output, schema=self.output_schema)
+        df = session.createDataFrame(output, schema=self.output_schema)
 
         df.dropDuplicates() \
           .coalesce(self.args.num_output_partitions) \


### PR DESCRIPTION
- simplify the code by passing SparkSession to methods instead of SparkSQLContext and SparkContext

Drawback:
- only marginal simplification
- would break forks/extension which override run_job(...), e.g. https://github.com/jaehunro/cc-pyspark/commit/891d800138c582a590d1da9c4436532e15b37d7e
