### PR TITLE
Adapt jobs for multi-valued headers in WAT data

### DIFF
--- a/server_count.py
+++ b/server_count.py
@@ -26,12 +26,19 @@ class ServerCountJob(CCSparkJob):
                 payload = record['Envelope']['Payload-Metadata']
                 if 'HTTP-Response-Metadata' in payload:
                     try:
-                        server_name = payload['HTTP-Response-Metadata'] \
-                                             ['Headers'] \
-                                             ['Server'] \
-                                             .strip()
-                        if server_name and server_name != '':
-                            yield server_name, 1
+                        server_names = []
+                        headers = payload['HTTP-Response-Metadata']['Headers']
+                        for header in headers:
+                             if header.lower() == 'server':
+                                 if isinstance(headers[header], list):
+                                     for server_name in headers[header]:
+                                         server_names.append(server_name.strip())
+                                 else:
+                                     server_names.append(headers[header].strip())
+                        if server_names:
+                            for server_name in server_names:
+                                if server_name != '':
+                                    yield server_name, 1
                         else:
                             yield ServerCountJob.fallback_server_name, 1
                     except KeyError:


### PR DESCRIPTION
Header data from WARC and HTTP headers will become multi-valued in WAT files. That is, the value is either a string or a list of strings. Jobs reading WAT files need to be adapted to the new data format.

See commoncrawl/ia-web-commons#18 and commoncrawl/ia-web-commons#38 for further details about multi-valued headers in WAT files.